### PR TITLE
also collect metrics regarding items in each of the slab classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ collecting statistics on memcached slabs.
 ## Description
 
 The memcached slab collector will gather all of the statistics output by
-`stats slabs`.  By default, you can find the resulting stats in
-`servers.[hostname].memcached_slab.*`.
+`stats slabs` and `stats items`.  By default, you can find the resulting stats
+in `servers.[hostname].memcached_slab.*`.
 
 ## Installation
 


### PR DESCRIPTION
Hello,

While going through the docs regarding service health, I came across [a section](https://github.com/memcached/memcached/wiki/ServerMaint#slab-imbalance) hinting at metrics reported by not just `stats slabs`, but also `stats items`. This patch adds the latter under `servers.[hostname].memcached_slab.items.*`. Since we're also moving to mcrouter, we're hoping these extra stats will help us determine if we're on the right track or not with our pool sizing and separation.